### PR TITLE
Add a --shrink flag, and improve Python 3 compatibility of that code

### DIFF
--- a/gditools3.py
+++ b/gditools3.py
@@ -815,7 +815,7 @@ def gdishrink(filename, odir=None, erase_bak=False, verbose=True):
         ofile.write(getDummyAudioTrack())
     # Moving the HD-area audio tracks too if they exist
     if numtraks > 3:
-        for iat, oat in zip(itracks, otracks)[3:-1]:    # Only the 2de session audio tracks
+        for iat, oat in list(zip(itracks, otracks))[3:-1]:    # Only the 2de session audio tracks
             if not os.path.isfile(oat['filename']):
                 shutil.copy2(iat['filename'], oat['filename'])
 


### PR DESCRIPTION
This adds the ability to use the gdishrink function from the command line, and additionally significantly improves the Python 3 compatibility of that code.

First up, it encodes some stuff which was strings as bytes.

Secondly, it fixes one instance where a calculation could sometimes result in a float value, which I believe Python 2 would transparently truncate to an int if needed, but Python 3 requires explicit truncation.

I'm not hugely familiar with getopt, so if there's a better way to insert these functions I'm all ears.